### PR TITLE
Delete redundant GLVertexArrayRegistry::initialize call

### DIFF
--- a/src/opengl/gl_renderer.cpp
+++ b/src/opengl/gl_renderer.cpp
@@ -24,9 +24,6 @@ std::unique_ptr<Swapchain> GLRenderer::createSwapchain(const SwapchainDescriptor
     auto context = GLContext::create(descriptor.surfaceDescriptor);
     NOX_ENSURE_RETURN_NULLPTR_MSG(context != nullptr, "Couldn't create context");
 
-    auto &vertexArrayRegistry = GLVertexArrayRegistry::instance();
-    vertexArrayRegistry.initialize();
-
     return std::make_unique<GLSwapchain>(descriptor, std::move(context));
 }
 

--- a/src/opengl/gl_vertex_array.cpp
+++ b/src/opengl/gl_vertex_array.cpp
@@ -70,14 +70,14 @@ GLVertexArrayRegistry &GLVertexArrayRegistry::instance() {
     return registry;
 }
 
+GLVertexArrayRegistry::GLVertexArrayRegistry() {
+    m_vertexArrays.emplace_back(GLVertexArray({}), 0u);
+}
+
 GLVertexArrayRegistry::~GLVertexArrayRegistry() {
     NOX_ASSERT(m_vertexArrays.size() == 1u);
 
     erase(0u);
-}
-
-void GLVertexArrayRegistry::initialize() {
-    [[maybe_unused]] auto index = registerVertexArray({});
 }
 
 uint32_t GLVertexArrayRegistry::registerVertexArray(const VertexAttributes &vertexAttributes) {

--- a/src/opengl/gl_vertex_array.h
+++ b/src/opengl/gl_vertex_array.h
@@ -35,8 +35,6 @@ class GLVertexArrayRegistry final {
   public:
     [[nodiscard]] static GLVertexArrayRegistry &instance();
 
-    void initialize();
-
     [[nodiscard]] uint32_t registerVertexArray(const VertexAttributes &vertexAttributes);
     void unregisterVertexArray(uint32_t index);
 
@@ -52,7 +50,7 @@ class GLVertexArrayRegistry final {
     void erase(uint32_t index);
 
   public:
-    GLVertexArrayRegistry() = default;
+    GLVertexArrayRegistry();
     GLVertexArrayRegistry(const GLVertexArrayRegistry &) = delete;
     GLVertexArrayRegistry &operator=(const GLVertexArrayRegistry &) = delete;
     GLVertexArrayRegistry(GLVertexArrayRegistry &&) = delete;


### PR DESCRIPTION
Signed-off-by: Rafal Maziejuk <rafalmaziejuk@gmail.com>
